### PR TITLE
fixing handling for retries and hubspot responses

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -140,7 +140,7 @@ HubSpot.prototype._create = function(properties, callback){
   .query({ hapikey: this.settings.apiKey })
   .send({ properties: properties })
   .end(function(err, res){
-    if (err) return callback(err);
+    if (err && err.status !== 409) return callback(err);
     var body = res.body;
 
     // If we receive anything other than a 409, return the request normally.
@@ -151,9 +151,12 @@ HubSpot.prototype._create = function(properties, callback){
     // If we receive a 409, decide to update. That means that the requests
     // were interleaved and the contact exists.
     try {
-      body = JSON.parse(body.message);
-      var vid = body.property.vid;
-      self.debug('contact with email %s already exists as %s', properties.email, vid);
+      var vid = body.identityProfile.vid;
+      var email = properties.filter(function(p){
+        return p.property == 'email';
+      })[0] || {};
+      email = email.value;
+      self.debug('contact with email %s already exists as %s', email, vid);
       self._update(vid, properties, callback);
     } catch (err) {
       callback(err);
@@ -175,7 +178,7 @@ HubSpot.prototype._getByEmail = function(email,callback){
   .set('Accept', 'application/json')
   .query({ hapikey: this.settings.apiKey })
   .end(function(err, res){
-    if (err) return callback(err);
+    if (err && err.status != 404) return callback(err);
     var body = res.body;
 
     if (res.statusCode === 404) {
@@ -183,13 +186,8 @@ HubSpot.prototype._getByEmail = function(email,callback){
       return callback();
     }
 
-    if (res.statusCode === 200) {
-      self.debug('user %s found successfully', email);
-      return callback(null, body);
-    }
-
-    self.debug('received a bad hubspot status %s', res.statusCode);
-    callback(self.error('error status=%s', res.statusCode));
+    self.debug('user %s found successfully', email);
+    return callback(null, body);
   });
 };
 


### PR DESCRIPTION
This change adds a check for error responses like 404s. It also
fixes a change HubSpot made in how their JSON responses came back
from their API for multiple visitors

@gjohnson 
