### PR TITLE
less requests: use create_or_update, only fetch properties when required

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+1.1.0 / 2016-11-16
+===================
+
+  * Use create or update endpoint for `.identify()` calls to reduce requests made 
+
 1.0.12 / 2016-08-31
 ===================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ HubSpot.prototype.initialize = function(){
   this.contactUrl = 'https://api.hubapi.com/contacts/v1';
   this.propertiesCache = new Cache({
     maxAge: ms('1h'),
-    max: 500
+    max: 1000
   }); // cache properties by api key
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,44 +87,70 @@ HubSpot.prototype.track = function(track, callback){
  * @api public
  */
 
-HubSpot.prototype.identify = function(identify, callback){
+HubSpot.prototype.identify = function(identify, callback) {
   var payload = mapper.identify(identify, this.settings);
   var self = this;
 
   // filter for existing properties
-  this._filterProperties(payload, function(err, properties){
+  this._filterProperties(payload, function(err, properties) {
     if (err) return callback(err);
 
-    self._getByEmail(identify.email(), function(err, user){
-      if (err) return callback(err);
+    var lcs = identify.proxy('traits.lifecyclestage');
+    if (lcs) {
+      return self._updateWithLCS(identify.email(), properties, lcs, callback);
+    }
 
-      // if user exists, we have to check to see how we will update
-      // their lifecyclestage (lcs) status
-      if (user) {
-        var lcs = identify.proxy('traits.lifecyclestage');
-        if (!lcs) return self._update(user.vid, properties, callback);
-
-        var existingLcs = user.properties && user.properties.lifescyclestage && user.properties.lifecyclestage.value;
-        var isNewerLcs = determineLcsStage(lcs, existingLcs);
-
-        // true, aka new LCS is more advanced or same as existing
-        if (isNewerLcs) return self._update(user.vid, properties, callback);
-
-        // false, aka new LCS is less advanced and so we first have to issue
-        // a call with empty lifecycle param to reset before updating
-        if (isNewerLcs === false) {
-          var emptyProps = [{ property: 'lifecyclestage', value: ''}];
-          return self._update(user.vid, emptyProps, function(err, res) {
-            if (err) return callback(err);
-            return self._update(user.vid, properties, callback);
-          });
-        }
-      }
-      // otherwise create the user
-      self._create(properties, callback);
-    });
+    self._createOrUpdate(identify.email(), properties, callback);
   });
 };
+
+/**
+ * Create or Update
+ */
+
+HubSpot.prototype._createOrUpdate = function(email, properties, callback) {
+  this
+    .post(fmt('%s/contact/createOrUpdate/email/%s', this.contactUrl, email))
+    .query({ hapikey: this.settings.apiKey })
+    .type('json')
+    .send({ properties: properties })
+    .end(this.handle(callback));
+}
+
+/**
+ * Update with LifeCycleStage
+ * Requires dedicated create/update endpoints, and uses more API calls
+ */
+
+HubSpot.prototype._updateWithLCS = function(email, properties, lcs, callback) {
+  var self = this;
+  this._getByEmail(email, function(err, user){
+    if (err) return callback(err);
+
+    // if user exists, we have to check to see how we will update
+    // their lifecyclestage (lcs) status based on if newer or older
+    if (user) {
+      var existingLcs = user.properties && user.properties.lifescyclestage && user.properties.lifecyclestage.value;
+      var isNewerLcs = determineLcsStage(lcs, existingLcs);
+
+      // true, aka new LCS is more advanced or same as existing
+      if (isNewerLcs) return self._update(user.vid, properties, callback);
+
+      // false, aka new LCS is less advanced and so we first have to issue
+      // a call with empty lifecycle param to reset before updating
+      if (isNewerLcs === false) {
+        var emptyProps = [{ property: 'lifecyclestage', value: ''}];
+        return self._update(user.vid, emptyProps, function(err, res) {
+          if (err) return callback(err);
+          return self._update(user.vid, properties, callback);
+        });
+      }
+    }
+
+    // otherwise just create the user
+    self._createOrUpdate(email, properties, callback);
+  });
+}
 
 /**
  * Updates a contact in HubSpot with the hubspot style `properties`
@@ -136,55 +162,12 @@ HubSpot.prototype.identify = function(identify, callback){
  */
 
 HubSpot.prototype._update = function(vid, properties, callback){
-
   this
     .post(fmt('%s/contact/vid/%s/profile', this.contactUrl, vid))
     .query({ hapikey: this.settings.apiKey })
     .type('json')
     .send({ properties: properties })
     .end(this.handle(callback));
-};
-
-/**
- * Create a new contact in HubSpot. If the contact exists, try and update it
- * instead.
- *
- * @param {Object} properties
- * @param {Function} callback  (err)
- * @api private
- */
-
-HubSpot.prototype._create = function(properties, callback){
-  var self = this;
-
-  this
-  .post(this.contactUrl + '/contact')
-  .type('json')
-  .query({ hapikey: this.settings.apiKey })
-  .send({ properties: properties })
-  .end(function(err, res){
-    if (err && err.status !== 409) return callback(err);
-    var body = res.body;
-
-    // If we receive anything other than a 409, return the request normally.
-    if (res.statusCode !== 409) {
-      return self.handle(callback).apply(self, arguments);
-    }
-
-    // If we receive a 409, decide to update. That means that the requests
-    // were interleaved and the contact exists.
-    try {
-      var vid = body.identityProfile.vid;
-      var email = properties.filter(function(p){
-        return p.property == 'email';
-      })[0] || {};
-      email = email.value;
-      self.debug('contact with email %s already exists as %s', email, vid);
-      self._update(vid, properties, callback);
-    } catch (err) {
-      callback(err);
-    }
-  });
 };
 
 /**
@@ -225,6 +208,9 @@ HubSpot.prototype._getByEmail = function(email,callback){
  */
 
 HubSpot.prototype._filterProperties = function(properties, callback){
+  if (!properties || !Object.keys(properties).length) {
+    return callback(null, []);
+  }
 
   var self = this;
   this._getProperties(function(err, existingProperties){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-hubspot",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "private": true,
   "description": "HubSpot server-side integration",
   "author": "Segment <friends@segment.com>",

--- a/test/index.js
+++ b/test/index.js
@@ -210,12 +210,12 @@ describe('HubSpot', function(){
     });
   });
 
-  describe('._create()', function(){
+  describe('._createOrUpdate()', function(){
     var email = fmt('test-%s@segment.io', uid());
     var properties = [{ property: 'email', value: email }];
 
-    it('should be able to ._create() once', function (done) {
-      hubspot._create(properties, done);
+    it('should be able to ._createOrUpdate() once', function (done) {
+      hubspot._createOrUpdate(email, properties, done);
     });
 
     var properties = [
@@ -223,9 +223,8 @@ describe('HubSpot', function(){
       { property: 'lifecyclestage', value: 'lead' }
     ];
 
-    it('should be able to ._update() on the second call', function (done) {
-
-      hubspot._create(properties, done);
+    it('should be able to ._createOrUpdate() on the second call', function (done) {
+      hubspot._createOrUpdate(email, properties, done);
     });
   });
 


### PR DESCRIPTION
@hankim813 @tsholmes 

Left the existing `getByEmail` and `update` methods in tact because I'm assuming we need to keep the request-heavy logic when advancing or downgrading user lifecycle stages, but we should check w/ HS on that because if that's not necessary we can delete a lot more code here. 
- [x] uses createOrUpdate instead of get+create/update for identify (unless lcs included explicitly in call)
- [x] return early in `filterProperties` if the trait object passed in doesn't exist or is empty (as is likely often the case for track calls). Removing this check from the events code path should also help reduce strain on rate limits for high volume customers
- [x] last thing we should check on is whether we can bump the cache size for properties beyond 500. i know this integration already uses a lot of memory so i'm not sure how best to evaluate or benchmark that @calvinfo 
